### PR TITLE
Improve documentation of insert placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ OpenAI Completion is a Sublime Text 4 plugin that uses the OpenAI natural langua
 ## Usage
 1. Open the Sublime Text 4 editor and select some code.
 2. Open the command palette and run the `OpenAI Append`, `OpenAI Insert`, or `OpenAI Edit` command.
+    - To use the `OpenAI Insert` command, the selected code should include a placeholder `[insert]`. This can be modified in the settings.
 3. **The plugin will send the selected code to the OpenAI servers**, using your API key, to generate a suggestion for editing the code.
 4. The suggestion will modify the selected code in the editor, according to the command you ran (append, insert, or edit).
 

--- a/openai.py
+++ b/openai.py
@@ -103,7 +103,7 @@ class OpenAIWorker(threading.Thread):
         parts = self.text.split(self.settings.get('placeholder'))
         try:
             if not len(parts) == 2:
-                raise AssertionError("There is no placeholder within the selected text, there should be exactly one.")
+                raise AssertionError("There is no placeholder '" + self.settings.get('placeholder') + "' within the selected text. There should be exactly one.")
         except Exception as ex:
             sublime.error_message("Exception\n" + str(ex))
             logging.exception("Exception: " + str(ex))


### PR DESCRIPTION
The default placeholder `[insert]` is not in the README. I had to look in the source code to figure out how to use OpenAI Insert.

This PR adds instructions to the README and provider better feedback to the user in the error message if the placeholder is missing.