### PR TITLE
Add a setting to integrate the AI generated code in the AI answer directly into the file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
+.DS_Store

--- a/main.py
+++ b/main.py
@@ -1,8 +1,10 @@
 import sys
 
 # clear modules cache if package is reloaded (after update?)
-prefix = __package__ + '.plugins'  # type: ignore # don't clear the base package
-for module_name in [module_name for module_name in sys.modules if module_name.startswith(prefix)]:
+prefix = __package__ + ".plugins"  # type: ignore # don't clear the base package
+for module_name in [
+    module_name for module_name in sys.modules if module_name.startswith(prefix)
+]:
     del sys.modules[module_name]
 del prefix
 
@@ -12,7 +14,10 @@ from .plugins.buffer import (  # noqa: E402, F401
     ReplaceRegionCommand,
     TextStreamAtCommand,
 )
-from .plugins.sheet_toggle import ToggleViewAiContextIncludedCommand, SelectSheetsWithAiContextIncludedCommand  # noqa: E402, F401
+from .plugins.sheet_toggle import (
+    ToggleViewAiContextIncludedCommand,
+    SelectSheetsWithAiContextIncludedCommand,
+)  # noqa: E402, F401
 from .plugins.openai import Openai  # noqa: E402, F401
 from .plugins.openai_panel import OpenaiPanelCommand  # noqa: E402, F401
 from .plugins.output_panel import SharedOutputPanelListener  # noqa: E402, F401

--- a/openAI.sublime-settings
+++ b/openAI.sublime-settings
@@ -32,6 +32,10 @@
 
         // For phantom mode, for "In New Tab" option you can set this to true to avoid save file on close dialog for each view opened by plugin
         "is_tabs_discardable": false,
+
+
+        // For phantom mode, extract the code from the AI response when integrating the answer inside a code file (copy, append, replace, new file)
+        "phantom_integrate_code_only": false,
     },
 
     // Minimum amount of characters selected to perform completion.

--- a/plugins/phantom_streamer.py
+++ b/plugins/phantom_streamer.py
@@ -21,21 +21,22 @@ from sublime import (
 from .load_model import get_cache_path
 from .output_panel import SharedOutputPanelListener
 from .response_manager import ResponseManager
+from .utils import extract_code_blocks
 
-OPENAI_COMPLETION_KEY = 'openai_completion'
+OPENAI_COMPLETION_KEY = "openai_completion"
 PHANTOM_TEMPLATE = (
-    '---'
-    + '\nallow_code_wrap: true'
-    + '\n---'
+    "---"
+    + "\nallow_code_wrap: true"
+    + "\n---"
     + '\n\n<a href="close">[x]</a> \
     | <a href="copy">Copy</a> \
     | <a href="append">Append</a> \
     | <a href="replace">Replace</a> \
     | <a href="new_file">In New Tab</a> \
     | <a href="history">Add to History</a>'
-    + '\n\n{streaming_content}'
+    + "\n\n{streaming_content}"
 )
-CLASS_NAME = 'openai-completion-phantom'
+CLASS_NAME = "openai-completion-phantom"
 
 logger = logging.getLogger(__name__)
 
@@ -50,18 +51,34 @@ class PhantomStreamer:
     ) -> None:
         self.view = view
         self.phantom_set = PhantomSet(self.view, OPENAI_COMPLETION_KEY)
-        self.completion: str = ''
+        self.completion: str = ""
         self.phantom: Phantom | None = None
         self.phantom_id: int | None = None
         self.user_input = user_input
         self.is_discardable: bool = (
-            load_settings('openAI.sublime-settings')
-            .get('chat_presentation', {})
-            .get('is_tabs_discardable', False)
+            load_settings("openAI.sublime-settings")
+            .get("chat_presentation", {})
+            .get("is_tabs_discardable", False)
         )
+        self.should_extract_code: bool = (
+            load_settings("openAI.sublime-settings")
+            .get("chat_presentation", {})
+            .get("phantom_integrate_code_only", False)
+        )
+        print("should_extract_code", self.should_extract_code)
         if len(view.sel()) > 0:
-            logger.debug(f'view selection: {view.sel()[0]}')
-            self.selected_region = view.sel()[0]  # saving only first selection to ease buffer logic
+            logger.debug(f"view selection: {view.sel()[0]}")
+            self.selected_region = view.sel()[
+                0
+            ]  # saving only first selection to ease buffer logic
+
+    @property
+    def completion_code(self):
+        """Returns the completion text according to the settings (either only the generated code or all the completion)"""
+        if self.should_extract_code:
+            return extract_code_blocks(self.completion)
+        else:
+            return self.completion
 
     def update_completion(self, completion: str):
         line_beginning = self.view.line(self.view.sel()[0])
@@ -84,31 +101,41 @@ class PhantomStreamer:
         set_timeout(update_main_thread)
 
     def close_phantom(self, attribute):
-        logger.debug(f'attribure: `{attribute}`')
+        logger.debug(f"attribure: `{attribute}`")
         if attribute in [action.value for action in PhantomActions]:
             if attribute == PhantomActions.copy.value:
-                set_clipboard(self.completion)
+                set_clipboard(self.completion_code)
             if attribute == PhantomActions.append.value:
                 self.view.run_command(
-                    'text_stream_at',
-                    {'position': self.selected_region.end(), 'text': self.completion},
+                    "text_stream_at",
+                    {
+                        "position": self.selected_region.end(),
+                        "text": self.completion_code,
+                    },
                 )
             elif attribute == PhantomActions.replace.value:
                 region_object = {
-                    'a': self.selected_region.begin(),
-                    'b': self.selected_region.end(),
+                    "a": self.selected_region.begin(),
+                    "b": self.selected_region.end(),
                 }
-                self.view.run_command('replace_region', {'region': region_object, 'text': self.completion})
+                self.view.run_command(
+                    "replace_region",
+                    {"region": region_object, "text": self.completion_code},
+                )
             elif attribute == PhantomActions.new_file.value:
                 new_tab = (self.view.window() or active_window()).new_file(
                     flags=NewFileFlags.ADD_TO_SELECTION | NewFileFlags.CLEAR_TO_RIGHT,
-                    syntax='Packages/Markdown/MultiMarkdown.sublime-syntax',
+                    syntax="Packages/Markdown/MultiMarkdown.sublime-syntax",
                 )
-                logger.debug(f'self.is_discardable: {self.is_discardable}')
+                logger.debug(f"self.is_discardable: {self.is_discardable}")
                 new_tab.set_scratch(self.is_discardable)
-                new_tab.run_command('text_stream_at', {'position': 0, 'text': self.completion})
+                new_tab.run_command(
+                    "text_stream_at", {"position": 0, "text": self.completion_code}
+                )
             elif attribute == PhantomActions.history.value:
-                assitant_content = SublimeInputContent(InputKind.AssistantResponse, self.completion)
+                assitant_content = SublimeInputContent(
+                    InputKind.AssistantResponse, self.completion
+                )
 
                 window = self.view.window() or active_window()
 
@@ -119,24 +146,32 @@ class PhantomStreamer:
                 ResponseManager.print_requests(listner, window, self.user_input)
 
                 ResponseManager.prepare_to_response(listner, window)
-                ResponseManager.update_output_panel_(listner, window, assitant_content.content)
+                ResponseManager.update_output_panel_(
+                    listner, window, assitant_content.content
+                )
 
                 self.user_input.append(assitant_content)
 
-                [write_to_cache(path, item) for item in self.user_input if item.input_kind != InputKind.Sheet]
+                [
+                    write_to_cache(path, item)
+                    for item in self.user_input
+                    if item.input_kind != InputKind.Sheet
+                ]
 
             elif attribute == PhantomActions.close.value:
                 pass
 
             self.phantom_set.update([])
         else:  # for handling all the rest URLs
-            (self.view.window() or active_window()).run_command('open_url', {'url': attribute})
+            (self.view.window() or active_window()).run_command(
+                "open_url", {"url": attribute}
+            )
 
 
 class PhantomActions(Enum):
-    close = 'close'
-    copy = 'copy'
-    append = 'append'
-    replace = 'replace'
-    new_file = 'new_file'
-    history = 'history'
+    close = "close"
+    copy = "copy"
+    append = "append"
+    replace = "replace"
+    new_file = "new_file"
+    history = "history"

--- a/plugins/utils.py
+++ b/plugins/utils.py
@@ -1,0 +1,18 @@
+import re
+
+
+def extract_code_blocks(md_text: str):
+    """
+    Return a list of the contents of each ```…``` code block in the given markdown. The code blocks must extend over multiple lines to be selected
+    """
+    # compile once
+    pattern = re.compile(r"```(?:[^\n`]*)\n([\s\S]*?)```")
+
+    # Remove all inline blocks that the model may generate (i.e. code blocks that are inline with the text or that are single line)
+    filtered = re.sub(r"```([^\n]*?)```", "", md_text)
+
+    # Get all the code blocks from the AI completion
+    blocks = pattern.findall(filtered)
+    # Join all code blocks in a string
+    completion_code = "\n\n".join(blocks)
+    return completion_code


### PR DESCRIPTION
In Phantom mode, created a new setting to only integrate the AI generated code without its comments and other markdown syntax. This new feature will extract from the AI generated answer the content of multiline code blocks when integrating the AI answer in a code file in any way. This will happen when the user will click on one of the following option (in phantom mode): Copy, Append, Replace, In New Tab. 